### PR TITLE
Replace both forward and backwards slashes in resource paths

### DIFF
--- a/src/main/java/de/bild/codec/TypesModel.java
+++ b/src/main/java/de/bild/codec/TypesModel.java
@@ -12,6 +12,7 @@ import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
 import org.springframework.core.io.support.ResourcePatternResolver;
 import org.springframework.util.ClassUtils;
 
+import java.io.File;
 import java.io.IOException;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.*;
@@ -66,7 +67,9 @@ public class TypesModel {
 
         default Class<?> loadClass(Pattern classPattern, String resourceName, ClassLoader classLoader) {
             try {
-                String resourcePathWithDots = resourceName.replace('/', '.');
+                // Replaces "/" for normal URL resources (e.g. jar) and separatorChar for file resources
+                // separatorChar is used to avoid replacing \ in UNIX paths while replacing them on Windows
+                String resourcePathWithDots = resourceName.replace('/', '.').replace(File.separatorChar, '.');
                 Matcher matcher = classPattern.matcher(resourcePathWithDots);
                 if (matcher.matches()) {
                     return classLoader.loadClass(matcher.group(1));


### PR DESCRIPTION
When running a project through IntelliJs "Application" run mode, classes were not being detected properly due to a bug in the `TypesModel`'s `PredefinedClassResolver` on [line 69](https://github.com/axelspringer/polymorphia/blob/master/src/main/java/de/bild/codec/TypesModel.java#L69)

Due to the way I ran the project, the resource URLs were in the format `file [C:\WindowsPath\AllTheDirectories\Class.class]`

This meant that this code:
```java
String resourcePathWithDots = resourceName.replace('/', '.')
```
was not replacing the Windows `\` and hence the classes were not being resolved correctly.

The change I propose continues to replace the `/` but also replaces the `File.pathSeparator` value, ensuring that `file` resource paths are correctly handled.